### PR TITLE
Change Fly deploy to trigger on release publish

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -2,9 +2,8 @@
 
 name: Fly Deploy
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 jobs:
   deploy:
     name: Deploy app


### PR DESCRIPTION
Match the docker-publish workflow behavior by deploying to Fly.io
only when a GitHub release is published, not on every push to main.

https://claude.ai/code/session_01CKQgAG2Fn2YDHpxbCfVddo