### PR TITLE
Rate limit new account creation

### DIFF
--- a/lib/reposit/rate_limiter.ex
+++ b/lib/reposit/rate_limiter.ex
@@ -7,6 +7,7 @@ defmodule Reposit.RateLimiter do
   - Search: 30 per minute per IP (calls OpenAI for embeddings)
   - Solution creation: 10 per minute per IP
   - Voting: 30 per minute per IP
+  - Account creation: 3 per hour per IP
   """
   use Hammer, backend: :ets
 
@@ -19,6 +20,7 @@ defmodule Reposit.RateLimiter do
   - `:search` - Search requests (uses OpenAI embeddings), 30/minute
   - `:create_solution` - Creating solutions, 10/minute
   - `:vote` - Voting on solutions, 30/minute
+  - `:create_account` - Creating accounts, 3/hour
 
   ## Returns
 
@@ -43,5 +45,6 @@ defmodule Reposit.RateLimiter do
   def rate_limit_for(:search), do: {:timer.minutes(1), 30}
   def rate_limit_for(:create_solution), do: {:timer.minutes(1), 10}
   def rate_limit_for(:vote), do: {:timer.minutes(1), 30}
+  def rate_limit_for(:create_account), do: {:timer.hours(1), 3}
   def rate_limit_for(_), do: {:timer.minutes(1), 100}
 end

--- a/lib/reposit_web/controllers/user_session_controller.ex
+++ b/lib/reposit_web/controllers/user_session_controller.ex
@@ -2,6 +2,7 @@ defmodule RepositWeb.UserSessionController do
   use RepositWeb, :controller
 
   alias Reposit.Accounts
+  alias Reposit.RateLimiter
   alias RepositWeb.UserAuth
 
   def new(conn, params) do
@@ -54,7 +55,7 @@ defmodule RepositWeb.UserSessionController do
       |> put_flash(:info, "We've sent you a magic link to sign in. Check your email!")
       |> redirect(to: ~p"/users/log-in")
     else
-      user = Accounts.get_user_by_email(email) || create_user(email)
+      user = get_or_create_user(conn, email)
       return_to = get_session(conn, :user_return_to)
 
       if user do
@@ -79,10 +80,31 @@ defmodule RepositWeb.UserSessionController do
   defp honeypot_filled?(%{"website" => value}) when byte_size(value) > 0, do: true
   defp honeypot_filled?(_), do: false
 
+  defp get_or_create_user(conn, email) do
+    Accounts.get_user_by_email(email) || maybe_create_user(conn, email)
+  end
+
+  defp maybe_create_user(conn, email) do
+    case RateLimiter.check_rate(client_ip(conn), :create_account) do
+      {:allow, _count} -> create_user(email)
+      {:deny, _retry_after} -> nil
+    end
+  end
+
   defp create_user(email) do
     case Accounts.register_user(%{email: email}) do
       {:ok, user} -> user
       {:error, _changeset} -> nil
+    end
+  end
+
+  defp client_ip(conn) do
+    case get_req_header(conn, "x-forwarded-for") do
+      [ips | _] ->
+        ips |> String.split(",") |> hd() |> String.trim()
+
+      [] ->
+        conn.remote_ip |> :inet.ntoa() |> to_string()
     end
   end
 

--- a/test/reposit/rate_limiter_test.exs
+++ b/test/reposit/rate_limiter_test.exs
@@ -25,6 +25,16 @@ defmodule Reposit.RateLimiterTest do
       assert {:deny, _retry_after} = RateLimiter.check_rate(ip, :create_solution)
     end
 
+    test "denies requests over the limit for create_account" do
+      ip = "account-#{System.unique_integer([:positive])}"
+
+      for i <- 1..3 do
+        assert {:allow, ^i} = RateLimiter.check_rate(ip, :create_account)
+      end
+
+      assert {:deny, _retry_after} = RateLimiter.check_rate(ip, :create_account)
+    end
+
     test "different IPs have independent limits" do
       ip1 = "ip1-#{System.unique_integer([:positive])}"
       ip2 = "ip2-#{System.unique_integer([:positive])}"
@@ -56,6 +66,7 @@ defmodule Reposit.RateLimiterTest do
       assert {60_000, 100} = RateLimiter.rate_limit_for(:api)
       assert {60_000, 10} = RateLimiter.rate_limit_for(:create_solution)
       assert {60_000, 30} = RateLimiter.rate_limit_for(:vote)
+      assert {3_600_000, 3} = RateLimiter.rate_limit_for(:create_account)
     end
 
     test "returns default limit for unknown actions" do

--- a/test/reposit_web/controllers/user_session_controller_test.exs
+++ b/test/reposit_web/controllers/user_session_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule RepositWeb.UserSessionControllerTest do
-  use RepositWeb.ConnCase, async: true
+  use RepositWeb.ConnCase, async: false
 
   import Reposit.AccountsFixtures
   alias Reposit.Accounts
@@ -115,6 +115,60 @@ defmodule RepositWeb.UserSessionControllerTest do
 
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "magic link to sign in"
       assert Accounts.get_user_by_email(email)
+    end
+
+    test "silently blocks new account creation after rate limit is exceeded", %{conn: conn} do
+      ip = "203.0.113.#{System.unique_integer([:positive])}"
+
+      for _ <- 1..3 do
+        email = "limited#{System.unique_integer([:positive])}@example.com"
+
+        conn =
+          conn
+          |> recycle()
+          |> put_req_header("x-forwarded-for", ip)
+          |> post(~p"/users/log-in", %{"user" => %{"email" => email}})
+
+        assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "magic link to sign in"
+        assert Accounts.get_user_by_email(email)
+      end
+
+      blocked_email = "limited#{System.unique_integer([:positive])}@example.com"
+
+      conn =
+        conn
+        |> recycle()
+        |> put_req_header("x-forwarded-for", ip)
+        |> post(~p"/users/log-in", %{"user" => %{"email" => blocked_email}})
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "magic link to sign in"
+      assert redirected_to(conn) == ~p"/users/log-in"
+      refute Accounts.get_user_by_email(blocked_email)
+    end
+
+    test "still sends magic link for existing user after account creation limit is exceeded", %{
+      conn: conn,
+      user: user
+    } do
+      ip = "203.0.113.#{System.unique_integer([:positive])}"
+
+      for _ <- 1..3 do
+        conn
+        |> recycle()
+        |> put_req_header("x-forwarded-for", ip)
+        |> post(~p"/users/log-in", %{
+          "user" => %{"email" => "limited#{System.unique_integer([:positive])}@example.com"}
+        })
+      end
+
+      conn =
+        conn
+        |> recycle()
+        |> put_req_header("x-forwarded-for", ip)
+        |> post(~p"/users/log-in", %{"user" => %{"email" => user.email}})
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "magic link to sign in"
+      assert Reposit.Repo.get_by!(Accounts.UserToken, user_id: user.id).context == "login"
     end
 
     test "logs the user in", %{conn: conn, user: user} do


### PR DESCRIPTION
## Summary
- add a stricter Hammer limit for new account creation: 3 per IP per hour
- apply the limit only when a login request would create a new user
- preserve existing-user magic link sign-in after the creation limit is exceeded
- keep blocked creation attempts silent so bots still see the normal success flash

Part of #6

## Testing
- mix test test/reposit/rate_limiter_test.exs test/reposit_web/controllers/user_session_controller_test.exs
- make dev.precommit